### PR TITLE
Changes releases not to be self-contained.

### DIFF
--- a/.github/workflows/chirp_release.yml
+++ b/.github/workflows/chirp_release.yml
@@ -45,7 +45,7 @@ jobs:
         release_name="Chirp-$tag-win-x64"
 
         # Build everything
-        dotnet publish /home/runner/work/Chirp/Chirp/Chirp.csproj --framework net7.0 --runtime "win-x64" -c Release -o "$release_name"
+        dotnet publish /home/runner/work/Chirp/Chirp/Chirp.csproj --framework net7.0 --runtime "win-x64" -c Release -o "$release_name" --self-contained false
 
         # Pack files
         7z a -tzip "${release_name}.zip" "./${release_name}/*"
@@ -61,7 +61,7 @@ jobs:
         release_name="Chirp-$tag-linux-x64"
 
         # Build everything
-        dotnet publish /home/runner/work/Chirp/Chirp/Chirp.csproj --framework net7.0 --runtime "linux-x64" -c Release -o "$release_name"
+        dotnet publish /home/runner/work/Chirp/Chirp/Chirp.csproj --framework net7.0 --runtime "linux-x64" -c Release -o "$release_name" --self-contained false
 
         # Pack files
         tar czvf "${release_name}.tar.gz" "$release_name"
@@ -77,7 +77,7 @@ jobs:
         release_name="Chirp-$tag-osx-x64"
 
         # Build everything
-        dotnet publish /home/runner/work/Chirp/Chirp/Chirp.csproj --framework net7.0 --runtime "osx-x64" -c Release -o "$release_name"
+        dotnet publish /home/runner/work/Chirp/Chirp/Chirp.csproj --framework net7.0 --runtime "osx-x64" -c Release -o "$release_name" --self-contained false
 
         # Pack files
         tar czvf "${release_name}.tar.gz" "$release_name"

--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,5 @@ obj/
 .history
 .ionide
 .idea
-data/chirp_cli_db.csv
+# data/chirp_cli_db.csv
 # End of https://www.toptal.com/developers/gitignore/api/dotnetcore,visualstudiocode

--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,5 @@ obj/
 .history
 .ionide
 .idea
-chirp_cli_db.csv
+data/chirp_cli_db.csv
 # End of https://www.toptal.com/developers/gitignore/api/dotnetcore,visualstudiocode

--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,5 @@ obj/
 .history
 .ionide
 .idea
-# data/chirp_cli_db.csv
+data/
 # End of https://www.toptal.com/developers/gitignore/api/dotnetcore,visualstudiocode

--- a/chirp_cli_db.csv
+++ b/chirp_cli_db.csv
@@ -1,7 +1,0 @@
-﻿Author,Message,Timestamp
-ropf,"Hello, BDSA students!",1690891760
-adho,"Welcome to the course!",1690978778
-adho,"I hope you had a good summer.",1690979858
-ropf,"Cheeping cheeps on Chirp :)",1690981487
-ronas,First message using SimpleDB!,1725519467
-ronas,Confirmed!,1725563201

--- a/data/chirp_cli_db.csv
+++ b/data/chirp_cli_db.csv
@@ -1,0 +1,7 @@
+﻿Author,Message,Timestamp
+ropf,"Hello, BDSA students!",1690891760
+adho,"Welcome to the course!",1690978778
+adho,"I hope you had a good summer.",1690979858
+ropf,"Cheeping cheeps on Chirp :)",1690981487
+ronas,First message using SimpleDB!,1725519467
+ronas,Confirmed!,1725563201


### PR DESCRIPTION
Closes #26 - Changes releases not to be self-contained. Saves GitHub resources and makes the program easier to download at this stage. 