### PR TITLE
Update .gitignore to keep out publish profiles.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ data/
 
 # Visual Studio 17
 .vs/
+
+# Publish profiles including keys for Visual Studio
+.pubxml.user
+.pubxml


### PR DESCRIPTION
Local publish profiles contain secrets. We do not want those in the repo. Use workflows instead.