### PR TITLE
Refactored Program class, in-memory database fix. 

### DIFF
--- a/src/Chirp.Web/Program.cs
+++ b/src/Chirp.Web/Program.cs
@@ -2,7 +2,6 @@ using Microsoft.EntityFrameworkCore;
 using Chirp.Infrastructure;
 using Chirp.Core;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.AspNetCore.Authentication.Cookies;
 using InvalidOperationException = System.InvalidOperationException;
 
 namespace Chirp.Web;
@@ -11,62 +10,18 @@ public class Program
 {
     public static void Main(string[] args)
     {
+        string dbPath = Environment.GetEnvironmentVariable("CHIRPDBPATH") ?? throw new InvalidOperationException("You must specify a environment variable CHIRPDBPATH, use eg. $env:CHIRPDBPATH=C:/Temp/db.db");
+        string connectionString = "Data Source=" + dbPath;
+        
         var builder = WebApplication.CreateBuilder(args);
 
-        string ChirpDBPath = Environment.GetEnvironmentVariable("CHIRPDBPATH") ?? throw new InvalidOperationException("You must specify a environment variable CHIRPDBPATH, use eg. $env:CHIRPDBPATH=C:/Temp/db.db");
-        string connectionString = "Data Source=" + ChirpDBPath;
-        builder.Services.AddDbContext<ChirpDBContext>(options => options.UseSqlite(connectionString));
-        builder.Services.AddScoped<ICheepRepository, CheepRepository>();
-        builder.Services.AddScoped<ICheepService, CheepService>();
-        builder.Services.AddRouting();
-        builder.Services.AddAuthentication(options => 
-        {
-            options.DefaultScheme = CookieAuthenticationDefaults.AuthenticationScheme;
-        })
-        .AddCookie()
-        .AddGitHub(o => 
-        {
-            o.ClientId = builder.Configuration["authentication:github:clientId"] ?? throw new InvalidOperationException("You must provide a github clientId");
-            o.ClientSecret = builder.Configuration["authentication:github:clientSecret"] ?? throw new InvalidOperationException("You must provide a github clientSecret");
-            o.CallbackPath = "/signin-github";
-        });
+        var startup = new Startup(builder.Configuration, connectionString);
 
-        builder.Services.AddDefaultIdentity<Author>(options => 
-        {
-            options.SignIn.RequireConfirmedAccount = true;
-        })
-            .AddEntityFrameworkStores<ChirpDBContext>();
-        
-        builder.Services.AddRazorPages();
+        startup.ConfigureServices(builder.Services);
 
         var app = builder.Build();
     
-        // Configure the HTTP request pipeline.
-        if (!app.Environment.IsDevelopment())
-        {
-            app.UseExceptionHandler("/Error");
-            // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
-            app.UseHsts();
-        }
-
-        // Database currently migrated and seeded on every start. 
-        // Remove when data needs to be persistent on server. 
-        using (var scope = app.Services.CreateScope())
-        {
-            using var context = scope.ServiceProvider.GetRequiredService<ChirpDBContext>();
-            using var userManager = scope.ServiceProvider.GetRequiredService<UserManager<Author>>();
-            context.Database.Migrate();
-            DbInitializer.SeedDatabase(context, userManager);
-        }
-
-        app.UseDeveloperExceptionPage();
-        app.UseHttpsRedirection();
-        app.UseStaticFiles();
-        app.UseRouting();
-        app.UseAuthentication();
-        app.UseAuthorization();
-
-        app.MapRazorPages();
+        startup.Configure(app);
 
         app.Run();
     }

--- a/src/Chirp.Web/Program.cs
+++ b/src/Chirp.Web/Program.cs
@@ -1,7 +1,3 @@
-using Microsoft.EntityFrameworkCore;
-using Chirp.Infrastructure;
-using Chirp.Core;
-using Microsoft.AspNetCore.Identity;
 using InvalidOperationException = System.InvalidOperationException;
 
 namespace Chirp.Web;

--- a/src/Chirp.Web/Program.cs
+++ b/src/Chirp.Web/Program.cs
@@ -1,3 +1,5 @@
+using Microsoft.Data.Sqlite;
+
 using InvalidOperationException = System.InvalidOperationException;
 
 namespace Chirp.Web;
@@ -6,12 +8,15 @@ public class Program
 {
     public static void Main(string[] args)
     {
-        string dbPath = Environment.GetEnvironmentVariable("CHIRPDBPATH") ?? throw new InvalidOperationException("You must specify a environment variable CHIRPDBPATH, use eg. $env:CHIRPDBPATH=C:/Temp/db.db");
-        string connectionString = "Data Source=" + dbPath;
-        
         var builder = WebApplication.CreateBuilder(args);
 
-        var startup = new Startup(builder.Configuration, connectionString);
+        string dbPath = Environment.GetEnvironmentVariable("CHIRPDBPATH") ?? throw new InvalidOperationException("You must specify a environment variable CHIRPDBPATH, use eg. $env:CHIRPDBPATH=C:/Temp/db.db");
+        string connectionString = "Data Source=" + dbPath;
+
+        using var dbConn = new SqliteConnection(connectionString);
+        dbConn.Open();
+
+        var startup = new Startup(builder.Configuration, dbConn);
 
         startup.ConfigureServices(builder.Services);
 

--- a/src/Chirp.Web/Startup.cs
+++ b/src/Chirp.Web/Startup.cs
@@ -1,8 +1,8 @@
 /*
  * The following methods are derived from the GitHub OAuth sample client:
  * https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/blob/dev/samples/Mvc.Client/Startup.cs
- * The methods have been adopted to help produce a cleaner code that is easier to test. 
- * They have been modified to suit the startup tasks of the Chirp web app. 
+ * The class is adopted to help produce a cleaner code that is easier to test. 
+ * It has been modified to suit the startup tasks of the Chirp web app. 
  *
  * Original header:
  *

--- a/src/Chirp.Web/Startup.cs
+++ b/src/Chirp.Web/Startup.cs
@@ -17,19 +17,16 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Chirp.Web;
 
-public class Startup
+public class Startup(IConfiguration configuration, string connectionString)
  {
-    public IConfiguration ?Configuration {get; set;}
-    public string ?ConnectionString {get; set;}
-
     public void ConfigureServices(IServiceCollection services)
     {
-        if (Configuration == null) throw new NullReferenceException("Missing builder configuration");
-        if (ConnectionString == null) throw new NullReferenceException("ConnectionString not set");
+        if (configuration == null) throw new NullReferenceException("Missing builder configuration");
+        if (connectionString == null) throw new NullReferenceException("ConnectionString not set");
 
         services.AddRouting();
 
-        services.AddDbContext<ChirpDBContext>(options => options.UseSqlite(ConnectionString));
+        services.AddDbContext<ChirpDBContext>(options => options.UseSqlite(connectionString));
 
         services.AddScoped<ICheepRepository, CheepRepository>();
 
@@ -44,8 +41,8 @@ public class Startup
 
         .AddGitHub(options =>
         {
-            options.ClientId = Configuration["authentication:github:clientId"] ?? throw new InvalidOperationException("Configuration missing a GitHub clientId");
-            options.ClientSecret = Configuration["authentication:github:clientSecret"] ?? throw new InvalidOperationException("Configuration missing a GitHub clientSecret");
+            options.ClientId = configuration["authentication:github:clientId"] ?? throw new InvalidOperationException("Configuration missing a GitHub clientId");
+            options.ClientSecret = configuration["authentication:github:clientSecret"] ?? throw new InvalidOperationException("Configuration missing a GitHub clientSecret");
             options.CallbackPath = "/signin-github";
         });
 

--- a/src/Chirp.Web/Startup.cs
+++ b/src/Chirp.Web/Startup.cs
@@ -1,0 +1,60 @@
+/*
+ * The following methods are derived from the GitHub OAuth sample client:
+ * https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers/blob/dev/samples/Mvc.Client/Startup.cs
+ * The methods have been adopted to help produce a cleaner code that is easier to test. 
+ * They have been modified to suit the startup tasks of the Chirp web app. 
+ *
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
+ * for more information concerning the license and the contributors participating to this project.
+ */
+
+using Chirp.Core;
+using Chirp.Infrastructure;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.EntityFrameworkCore;
+
+namespace Chirp.Web;
+
+public class Startup
+ {
+    public IConfiguration ?Configuration {get; set;}
+    public IWebHostEnvironment ?Environment {get; set;}
+    public string ?ConnectionString {get; set;}
+
+    public void ConfigureServices(IServiceCollection services)
+    {
+        if (Configuration == null) throw new NullReferenceException("Missing builder configuration");
+        if (ConnectionString == null) throw new NullReferenceException("ConnectionString not set");
+
+        services.AddRouting();
+
+        services.AddDbContext<ChirpDBContext>(options => options.UseSqlite(ConnectionString));
+
+        services.AddScoped<ICheepRepository, CheepRepository>();
+
+        services.AddScoped<ICheepService, CheepService>();
+
+        services.AddAuthentication(options =>
+        {
+            options.DefaultScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+        })
+        
+        .AddCookie()
+
+        .AddGitHub(options =>
+        {
+            options.ClientId = Configuration["authentication:github:clientId"] ?? throw new InvalidOperationException("Configuration missing a GitHub clientId");
+            options.ClientSecret = Configuration["authentication:github:clientSecret"] ?? throw new InvalidOperationException("Configuration missing a GitHub clientSecret");
+            options.CallbackPath = "/signin-github";
+        });
+
+        services.AddDefaultIdentity<Author>(options => 
+        {
+            options.SignIn.RequireConfirmedAccount = true;
+        })
+            .AddEntityFrameworkStores<ChirpDBContext>();
+        
+        services.AddRazorPages();
+    }
+ }

--- a/src/Chirp.Web/Startup.cs
+++ b/src/Chirp.Web/Startup.cs
@@ -4,6 +4,8 @@
  * The methods have been adopted to help produce a cleaner code that is easier to test. 
  * They have been modified to suit the startup tasks of the Chirp web app. 
  *
+ * Original header:
+ *
  * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
  * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers
  * for more information concerning the license and the contributors participating to this project.

--- a/src/Chirp.Web/Startup.cs
+++ b/src/Chirp.Web/Startup.cs
@@ -13,20 +13,18 @@ using Chirp.Core;
 using Chirp.Infrastructure;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 
 namespace Chirp.Web;
 
-public class Startup(IConfiguration configuration, string connectionString)
+public class Startup(IConfiguration configuration, SqliteConnection dbConn)
  {
     public void ConfigureServices(IServiceCollection services)
     {
-        if (configuration == null) throw new NullReferenceException("Missing builder configuration");
-        if (connectionString == null) throw new NullReferenceException("ConnectionString not set");
-
         services.AddRouting();
 
-        services.AddDbContext<ChirpDBContext>(options => options.UseSqlite(connectionString));
+        services.AddDbContext<ChirpDBContext>(options => options.UseSqlite(dbConn));
 
         services.AddScoped<ICheepRepository, CheepRepository>();
 


### PR DESCRIPTION
- Taking inspiration from https://github.com/aspnet-contrib/AspNet.Security.OAuth.Providers sample application.

I have created our own version of their `Startup` class. This now contains a lot of the settings and configurations we are doing when starting the web app. 

- `void ConfigureServices(IServiceCollection services)` Registers all injected dependencies for application services. 
- `void Configure(WebApplication app)` Builds the middleware pipeline as preparation for the app to run. 

The startup class has a relatively simple constructor, taking two params:
- `IConfiguration configuration` for the `builder.Configuration` needed mainly for accessing GH client secrets. 
- `SqliteConnection dbConn` takes an open SQLite connection. (`using var`  statement ensures closure) This allows in-memory testing to work properly, meaning that a well seeded database can be relied on for integration tests!